### PR TITLE
Remove duplicate directory (`2025-release-25.1/` is the right one)

### DIFF
--- a/release_25.1/index.html
+++ b/release_25.1/index.html
@@ -1,1 +1,0 @@
-<html><head><meta http-equiv='refresh' content='0; URL=https://presentations.clickhouse.com/?path=2025-release-25.1'></head><body></body><html>


### PR DESCRIPTION
Please make sure the pull request conforms to the folder naming convention in this repository.

- For *meetups*, the folder should be called `<year>-meetup-<city>`, e.g. `2025-meetup-new-york`.

- For *conferences*, the folder should be called `<year>-<conference>`, e.g. `2025-database-days`.

- For *release webinars*, the folder should be called `<year>-release-<version>`, e.g. `2025-release-25.1`.

If a folder exists already, e.g. because there were two meetups in New York in 2025, append `-2`, `-3` to the folder name.
