### PR TITLE
Fix url to get content of presentations

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
 
     try {
       const response = await fetch(
-        "https://api.github.com/repos/ClickHouse/clickhouse-presentations/contents" +
+        "https://api.github.com/repos/ClickHouse/clickhouse-presentations/contents/" +
         (params.path || "/")
       );
       const data = await response.json();


### PR DESCRIPTION
Please make sure the pull request conforms to the folder naming convention in this repository.

- For *meetups*, the folder should be called `<year>-meetup-<city>`, e.g. `2025-meetup-new-york`.

- For *conferences*, the folder should be called `<year>-<conference>`, e.g. `2025-database-days`.

- For *release webinars*, the folder should be called `<year>-release-<version>`, e.g. `2025-release-25.1`.

If a folder exists already, e.g. because there were two meetups in New York in 2025, append `-2`, `-3` to the folder name.
