### PR TITLE
Decks for 2025 Beijing Meetup

### DIFF
--- a/2025-meetup-Beijing/README.md
+++ b/2025-meetup-Beijing/README.md
@@ -1,0 +1,11 @@
+Meetup agenda
+Time：20 Sep 2025
+Venue: Beijing Fourpoint Sheraton hotel (Building 1, YuanDa Road, Haidian District, Beijing)
+13:30~13:40 opening
+13:40~14:10 The Infrastructure integration and core innovation of Clickhouse for searching and analysis of logging scenario - By Tianqi Zheng （Amos Bird）, leader of ES engine, Tencent Cloud
+14:10~14:40 ClickHouse New JSON type - By Tianqi Zheng, senior software engineer, ClickHouse Inc
+14:40~15:10 Timeplus + ClickHouse, real time data analytics - by Tian Fan, senior Architect from Timeplus
+15:10~15:30 Tea Break
+15:30~16:00 Build Observability platform using ClickHouse - By Xiaoyu Zeng, product manager from Database department, AliCloud 
+16:00~16:30 Stream data processing and analytics, Risingwave + ClickHouse by Yiming Wen, core engineer from Risingwave Labs
+16:30~17:00 QA and closing


### PR DESCRIPTION
Please make sure the pull request conforms to the folder naming convention in this repository.

- For *meetups*, the folder should be called `<year>-meetup-<city>`, e.g. `2025-meetup-new-york`.

- For *conferences*, the folder should be called `<year>-<conference>`, e.g. `2025-database-days`.

- For *release webinars*, the folder should be called `<year>-release-<version>`, e.g. `2025-release-25.1`.

If a folder exists already, e.g. because there were two meetups in New York in 2025, append `-2`, `-3` to the folder name.
