### PR TITLE
Add the User Council Amsterdam presentation to the theater page

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,6 +214,10 @@
 
     <div class="container">
         <div class="grid" id="grid">
+<a href="2026-user-council-amsterdam/" class="card" data-title="clickhouse: my favorite features">
+    <img src="2026-user-council-amsterdam/pictures/preview.jpg" alt="ClickHouse: My Favorite Features" loading="lazy">
+    <div class="card-title">ClickHouse: My Favorite Features</div>
+</a>
 <a href="2026-release-26.8/" class="card" data-title="clickhouse: release 26.8 call">
     <img src="2026-release-26.8/pictures/preview.jpg" alt="ClickHouse: Release 26.8 Call" loading="lazy">
     <div class="card-title">ClickHouse: Release 26.8 Call</div>


### PR DESCRIPTION
Adds the card for `2026-user-council-amsterdam` (merged in #146) at the top of the theater page.

Inserted by hand rather than by running `generate_theater.py`: the generator drops three hand-added cards that it cannot produce — the two FOSDEM PDF links (`2026-fosdem-inverted-index`, `2026-fosdem-hotpatching`) and `original_website/` — and reshuffles the order of ~100 other cards. This change is 4 added lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)